### PR TITLE
feat: add commercial nix profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,11 @@ See the LICENSE file for complete attribution information.
 
 ## Build darwin flake using:
 ```bash
-# Build the configuration
-darwin-rebuild build --flake .
+# Build the standard profile
+darwin-rebuild build --flake .#standard
 
-# Switch to the new configuration
-sudo darwin-rebuild switch --flake .
+# Switch to the standard profile
+sudo darwin-rebuild switch --flake .#standard
 ```
+Replace `standard` with `commercial` for the commercial profile.
+

--- a/nix/env.nix
+++ b/nix/env.nix
@@ -1,8 +1,14 @@
 {
   hosts = {
-    "{{LOCAL_HOSTNAME}}" = {
+    standard = {
       system = "aarch64-darwin";
       username = "{{USER_NAME}}";
+      profile = "standard";
+    };
+    commercial = {
+      system = "aarch64-darwin";
+      username = "{{USER_NAME}}";
+      profile = "commercial";
     };
   };
 

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -1,23 +1,6 @@
 { pkgs, ... }:
-
-{
-  home.packages = with pkgs; [
-    # shell utilities
-    zsh
-    fish
-    starship
-
-    # development tools
-    gh
-    git
-    gnupg
-    curl
-    wget
-
-    # coding agents
-    pinentry_mac
-    claude-code
-    codex
-    gemini-cli
-  ];
+let
+  packages = import ../../packages/standard.nix { inherit pkgs; };
+in {
+  home.packages = packages;
 }

--- a/nix/packages/standard.nix
+++ b/nix/packages/standard.nix
@@ -1,0 +1,20 @@
+{ pkgs }:
+with pkgs; [
+  # shell utilities
+  zsh
+  fish
+  starship
+
+  # development tools
+  gh
+  git
+  gnupg
+  curl
+  wget
+
+  # coding agents
+  pinentry_mac
+  claude-code
+  codex
+  gemini-cli
+]

--- a/nix/parts/darwin.nix
+++ b/nix/parts/darwin.nix
@@ -6,34 +6,54 @@ let
   env = import ../env.nix;
   configurations = env.hosts;
 
+  # Profile-specific modules
+  profileDarwinModules = {
+    standard = ../profiles/standard/darwin/standard.nix;
+    commercial = ../profiles/commercial/darwin/commercial.nix;
+  };
+
+  profileHomeModules = {
+    commercial = ../profiles/commercial/home/commercial.nix;
+  };
+
   # Create Darwin configurations for all hosts
   mkDarwinConfigurations = lib.mapAttrs (hostName: hostConfig:
+    let
+      profile = hostConfig.profile or "standard";
+      profileModule = profileDarwinModules.${profile} or null;
+      profileHomeModule = profileHomeModules.${profile} or null;
+    in
     inputs.nix-darwin.lib.darwinSystem {
       inherit (hostConfig) system;
-      modules = [
-        inputs.brew-nix.darwinModules.default
-        inputs.home-manager.darwinModules.home-manager
-        ../modules/darwin
-        ../modules/homebrew
-        ../modules/nixpkgs/unfree.nix
-        ../modules/nixpkgs/overlays.nix
-        ../hosts/darwin.nix        # Base Darwin settings
-        ../profiles/standard/darwin/standard.nix  # Standard profile
-        { networking.hostName = hostName; }
-        {
-          home-manager = {
-            useGlobalPkgs = true;
-            useUserPackages = true;
-            users.${hostConfig.username} = {
-              imports = [ ../modules/home/home-manager.nix ];
-              home = {
-                inherit (hostConfig) username;
-                homeDirectory = "/Users/${hostConfig.username}";
+      modules =
+        [
+          inputs.brew-nix.darwinModules.default
+          inputs.home-manager.darwinModules.home-manager
+          ../modules/darwin
+          ../modules/homebrew
+          ../modules/nixpkgs/unfree.nix
+          ../modules/nixpkgs/overlays.nix
+          ../hosts/darwin.nix        # Base Darwin settings
+        ]
+        ++ lib.optional (profileModule != null) profileModule
+        ++ [
+          { networking.hostName = hostName; }
+          {
+            home-manager = {
+              useGlobalPkgs = true;
+              useUserPackages = true;
+              users.${hostConfig.username} = {
+                imports =
+                  [ ../modules/home/home-manager.nix ]
+                  ++ lib.optional (profileHomeModule != null) profileHomeModule;
+                home = {
+                  inherit (hostConfig) username;
+                  homeDirectory = "/Users/${hostConfig.username}";
+                };
               };
             };
-          };
-        }
-      ];
+          }
+        ];
       specialArgs = {
         inherit self hostName;
         inherit (inputs) brew-nix;

--- a/nix/parts/home.nix
+++ b/nix/parts/home.nix
@@ -5,19 +5,30 @@ let
   env = import ../env.nix;
   configurations = env.hosts;
 
+  # Profile-specific home modules
+  profileHomeModules = {
+    commercial = ../profiles/commercial/home/commercial.nix;
+  };
+
   # Create Home Manager configurations for all hosts
   mkHomeConfigurations = lib.mapAttrs (hostName: hostConfig:
+    let
+      profile = hostConfig.profile or "standard";
+      profileHomeModule = profileHomeModules.${profile} or null;
+    in
     inputs.home-manager.lib.homeManagerConfiguration {
       pkgs = import ../modules/nixpkgs { inherit inputs; inherit (hostConfig) system; };
-      modules = [
-        ../modules/home/home-manager.nix
-        {
-          home = {
-            inherit (hostConfig) username;
-            homeDirectory = "/Users/${hostConfig.username}";
-          };
-        }
-      ];
+      modules =
+        [ ../modules/home/home-manager.nix ]
+        ++ lib.optional (profileHomeModule != null) profileHomeModule
+        ++ [
+          {
+            home = {
+              inherit (hostConfig) username;
+              homeDirectory = "/Users/${hostConfig.username}";
+            };
+          }
+        ];
     }
   ) configurations;
 in

--- a/nix/parts/modules.nix
+++ b/nix/parts/modules.nix
@@ -10,6 +10,7 @@
       homebrew = ../modules/homebrew;
       darwin-base = ../hosts;
       standard-host = ../profiles/standard/darwin/standard.nix;
+      commercial-host = ../profiles/commercial/darwin/commercial.nix;
     };
 
     homeManagerModules = {

--- a/nix/profiles/commercial/darwin/commercial.nix
+++ b/nix/profiles/commercial/darwin/commercial.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  imports = [ ../../standard/darwin/standard.nix ];
+}

--- a/nix/profiles/commercial/home/commercial.nix
+++ b/nix/profiles/commercial/home/commercial.nix
@@ -1,0 +1,7 @@
+{ pkgs, lib, ... }:
+let
+  standardPackages = import ../../../packages/standard.nix { inherit pkgs; };
+  banned = with pkgs; [ claude-code codex gemini-cli ];
+in {
+  home.packages = lib.subtractLists banned standardPackages;
+}


### PR DESCRIPTION
## Summary
- allow selecting host profile via `.#<profile>` and add new `commercial` profile
- share package list and drop non-commercial packages for commercial use
- document profile selection in README

## Testing
- `nix --extra-experimental-features "nix-command flakes" flake check` *(fails: unknown flake output 'homeManagerModules'; The check omitted these incompatible systems: aarch64-darwin)*

------
https://chatgpt.com/codex/tasks/task_e_688fdb6092f08320ad00fef66ea83e94